### PR TITLE
Implement favorites

### DIFF
--- a/EventPlanner/app/src/main/java/m3/eventplanner/activities/MainActivity.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/activities/MainActivity.java
@@ -77,6 +77,7 @@ public class MainActivity extends AppCompatActivity {
         topLevelDestinations.add(R.id.createProductFragment);
         topLevelDestinations.add((R.id.categoryFragment));
         topLevelDestinations.add(R.id.userDetailsFragment);
+        topLevelDestinations.add(R.id.favouritesFragment);
 
         navController = Navigation.findNavController(this, R.id.fragment_nav_content_main);
 

--- a/EventPlanner/app/src/main/java/m3/eventplanner/adapters/EventListAdapter.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/adapters/EventListAdapter.java
@@ -66,7 +66,7 @@ public class EventListAdapter extends RecyclerView.Adapter<EventListAdapter.Even
         holder.eventCard.setOnClickListener(v -> {
             Bundle bundle = new Bundle();
             bundle.putInt("selectedEventId", event.getId());
-            Navigation.findNavController(v).navigate(R.id.action_homeScreenFragment_to_eventDetailsFragment, bundle);
+            Navigation.findNavController(v).navigate(R.id.eventDetailsFragment, bundle);
         });
     }
 

--- a/EventPlanner/app/src/main/java/m3/eventplanner/clients/AccountService.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/clients/AccountService.java
@@ -3,6 +3,7 @@ package m3.eventplanner.clients;
 import m3.eventplanner.models.AddFavouriteEventDTO;
 import m3.eventplanner.models.Event;
 import m3.eventplanner.models.GetEventDTO;
+import m3.eventplanner.models.GetOfferingDTO;
 import m3.eventplanner.models.PagedResponse;
 import retrofit2.Call;
 import retrofit2.http.Body;
@@ -46,5 +47,14 @@ public interface AccountService {
     })
     @DELETE("accounts/{accountId}/favourite-events/{eventId}")
     Call<Void> removeEventFromFavourites(@Path("accountId") int accountId, @Path("eventId") int eventId);
+
+    @Headers({
+            "User-Agent: Mobile-Android",
+            "Content-Type: application/json"
+    })
+    @GET("accounts/{accountId}/favourite-offerings")
+    Call<PagedResponse<GetOfferingDTO>> getFavouriteOfferings(@Path("accountId") int accountId,
+                                                              @Query("page") int page,
+                                                              @Query("size") int size);
 }
 

--- a/EventPlanner/app/src/main/java/m3/eventplanner/clients/AccountService.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/clients/AccountService.java
@@ -22,7 +22,9 @@ public interface AccountService {
             "Content-Type: application/json"
     })
     @GET("accounts/{accountId}/favourite-events")
-    Call<Collection<GetEventDTO>> getFavouriteEvents(@Path("accountId") int accountId);
+    Call<PagedResponse<GetEventDTO>> getFavouriteEvents(@Path("accountId") int accountId,
+                                                        @Query("page") int page,
+                                                        @Query("size") int size);
 
     @Headers({
             "User-Agent: Mobile-Android",

--- a/EventPlanner/app/src/main/java/m3/eventplanner/clients/AccountService.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/clients/AccountService.java
@@ -28,6 +28,13 @@ public interface AccountService {
             "User-Agent: Mobile-Android",
             "Content-Type: application/json"
     })
+    @GET("accounts/{accountId}/favourite-events/{eventId}")
+    Call<GetEventDTO> getFavouriteEvent(@Path("accountId") int accountId, @Path("eventId") int eventId);
+
+    @Headers({
+            "User-Agent: Mobile-Android",
+            "Content-Type: application/json"
+    })
     @POST("accounts/{accountId}/favourite-events")
     Call<Void> addEventToFavourites(@Path("accountId") int accountId, @Body AddFavouriteEventDTO addFavouriteEventDTO);
 

--- a/EventPlanner/app/src/main/java/m3/eventplanner/fragments/event/EventDetailsViewModel.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/fragments/event/EventDetailsViewModel.java
@@ -104,19 +104,21 @@ public class EventDetailsViewModel extends ViewModel {
             return;
 
         // Check if event is favourite
-        clientUtils.getAccountService().getFavouriteEvents(accountId).enqueue(new Callback<Collection<GetEventDTO>>() {
+        clientUtils.getAccountService().getFavouriteEvent(accountId,eventId).enqueue(new Callback<GetEventDTO>() {
             @Override
-            public void onResponse(Call<Collection<GetEventDTO>> call, Response<Collection<GetEventDTO>> response) {
+            public void onResponse(Call<GetEventDTO> call, Response<GetEventDTO> response) {
                 if (response.isSuccessful() && response.body() != null) {
-                    boolean isFav = response.body().stream().anyMatch(e -> e.getId() == eventId);
-                    isFavourite.setValue(isFav);
+                    isFavourite.setValue(true);
                 } else {
-                    error.setValue("Failed to check favourite status");
+                    if(response.code()==404)
+                        isFavourite.setValue(false);
+                    else
+                        error.setValue("Failed to check favourite status");
                 }
             }
 
             @Override
-            public void onFailure(Call<Collection<GetEventDTO>> call, Throwable t) {
+            public void onFailure(Call<GetEventDTO> call, Throwable t) {
                 error.setValue(t.getMessage() != null ? t.getMessage() : "Error checking favourite status");
             }
         });

--- a/EventPlanner/app/src/main/java/m3/eventplanner/fragments/user/FavouritesFragment.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/fragments/user/FavouritesFragment.java
@@ -66,6 +66,7 @@ public class FavouritesFragment extends Fragment {
                 binding.eventRecyclerView.setAdapter(eventAdapter);
                 eventAdapter.notifyDataSetChanged();
                 binding.eventRecyclerView.setVisibility(View.VISIBLE);
+                binding.eventPaginationBar.getRoot().setVisibility(View.VISIBLE);
                 binding.noEventsFoundTextView.setVisibility(View.GONE);
                 binding.eventPaginationBar.paginationCurrentPage.setText(String.valueOf("Page "+ (viewModel.currentEventPage + 1) +" of "+ viewModel.totalEventPages));
                 binding.eventPaginationBar.totalNumberOfElements.setText(String.format("Total Elements: %d", viewModel.totalEventElements));
@@ -73,6 +74,23 @@ public class FavouritesFragment extends Fragment {
                 binding.noEventsFoundTextView.setVisibility(View.VISIBLE);
                 binding.eventRecyclerView.setVisibility(View.GONE);
                 binding.eventPaginationBar.getRoot().setVisibility(View.GONE);
+            }
+        });
+
+        viewModel.getFavouriteOfferings().observe(getViewLifecycleOwner(), pagedOfferings -> {
+            if (pagedOfferings != null && !pagedOfferings.getContent().equals(new ArrayList<>())) {
+                offeringAdapter = new OfferingListAdapter(pagedOfferings.getContent());
+                binding.offeringRecyclerView.setAdapter(offeringAdapter);
+                offeringAdapter.notifyDataSetChanged();
+                binding.offeringRecyclerView.setVisibility(View.VISIBLE);
+                binding.offeringPaginationBar.getRoot().setVisibility(View.VISIBLE);
+                binding.noOfferingsFoundTextView.setVisibility(View.GONE);
+                binding.offeringPaginationBar.paginationCurrentPage.setText(String.valueOf("Page "+ (viewModel.currentOfferingPage + 1) +" of "+ viewModel.totalOfferingPages));
+                binding.offeringPaginationBar.totalNumberOfElements.setText(String.format("Total Elements: %d", viewModel.totalOfferingElements));
+            } else {
+                binding.noOfferingsFoundTextView.setVisibility(View.VISIBLE);
+                binding.offeringRecyclerView.setVisibility(View.GONE);
+                binding.offeringPaginationBar.getRoot().setVisibility(View.GONE);
             }
         });
 
@@ -90,6 +108,15 @@ public class FavouritesFragment extends Fragment {
             viewModel.fetchPreviousEventPage();
         });
 
+        binding.offeringPaginationBar.paginationForwardButton.setOnClickListener(v -> {
+            viewModel.fetchNextOfferingPage();
+        });
+
+        binding.offeringPaginationBar.paginationBackButton.setOnClickListener(v -> {
+            viewModel.fetchPreviousOfferingPage();
+        });
+
         viewModel.fetchEventPage(0);
+        viewModel.fetchOfferingPage(0);
     }
 }

--- a/EventPlanner/app/src/main/java/m3/eventplanner/fragments/user/FavouritesFragment.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/fragments/user/FavouritesFragment.java
@@ -1,0 +1,95 @@
+package m3.eventplanner.fragments.user;
+
+import android.media.session.MediaSession;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.recyclerview.widget.LinearLayoutManager;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
+
+import java.util.ArrayList;
+
+import m3.eventplanner.R;
+import m3.eventplanner.adapters.EventListAdapter;
+import m3.eventplanner.adapters.OfferingListAdapter;
+import m3.eventplanner.auth.TokenManager;
+import m3.eventplanner.clients.ClientUtils;
+import m3.eventplanner.databinding.FragmentFavouritesBinding;
+import m3.eventplanner.databinding.FragmentUserDetailsBinding;
+import m3.eventplanner.fragments.event.EventDetailsViewModel;
+
+public class FavouritesFragment extends Fragment {
+    private FragmentFavouritesBinding binding;
+    private FavouritesViewModel viewModel;
+    private ClientUtils clientUtils;
+    private EventListAdapter eventAdapter;
+    private OfferingListAdapter offeringAdapter;
+
+    public FavouritesFragment() {
+        // Required empty public constructor
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        binding = FragmentFavouritesBinding.inflate(inflater, container, false);
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        viewModel = new ViewModelProvider(this).get(FavouritesViewModel.class);
+        TokenManager tokenManager = new TokenManager(requireContext());
+        this.clientUtils = new ClientUtils(requireContext());
+        viewModel.initialize(clientUtils,tokenManager.getAccountId());
+
+        binding.eventRecyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+        binding.offeringRecyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+
+        viewModel.getFavouriteEvents().observe(getViewLifecycleOwner(), pagedEvents -> {
+            if (pagedEvents != null && !pagedEvents.getContent().equals(new ArrayList<>())) {
+                eventAdapter = new EventListAdapter(pagedEvents.getContent());
+                binding.eventRecyclerView.setAdapter(eventAdapter);
+                eventAdapter.notifyDataSetChanged();
+                binding.eventRecyclerView.setVisibility(View.VISIBLE);
+                binding.noEventsFoundTextView.setVisibility(View.GONE);
+                binding.eventPaginationBar.paginationCurrentPage.setText(String.valueOf("Page "+ (viewModel.currentEventPage + 1) +" of "+ viewModel.totalEventPages));
+                binding.eventPaginationBar.totalNumberOfElements.setText(String.format("Total Elements: %d", viewModel.totalEventElements));
+            } else {
+                binding.noEventsFoundTextView.setVisibility(View.VISIBLE);
+                binding.eventRecyclerView.setVisibility(View.GONE);
+                binding.eventPaginationBar.getRoot().setVisibility(View.GONE);
+            }
+        });
+
+        viewModel.getError().observe(getViewLifecycleOwner(), errorMessage -> {
+            if (errorMessage != null && !errorMessage.isEmpty()) {
+                Toast.makeText(getContext(), errorMessage, Toast.LENGTH_SHORT).show();
+            }
+        });
+
+        binding.eventPaginationBar.paginationForwardButton.setOnClickListener(v -> {
+            viewModel.fetchNextEventPage();
+        });
+
+        binding.eventPaginationBar.paginationBackButton.setOnClickListener(v -> {
+            viewModel.fetchPreviousEventPage();
+        });
+
+        viewModel.fetchEventPage(0);
+    }
+}

--- a/EventPlanner/app/src/main/java/m3/eventplanner/fragments/user/FavouritesViewModel.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/fragments/user/FavouritesViewModel.java
@@ -1,0 +1,77 @@
+package m3.eventplanner.fragments.user;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+import m3.eventplanner.clients.ClientUtils;
+import m3.eventplanner.models.GetEventDTO;
+import m3.eventplanner.models.PagedResponse;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class FavouritesViewModel extends ViewModel {
+    private ClientUtils clientUtils;
+    public final MutableLiveData<PagedResponse<GetEventDTO>> favouriteEvents = new MutableLiveData<>();
+    public final MutableLiveData<String> error = new MutableLiveData<>();
+    public int currentEventPage = 0;
+    public int totalEventPages = 0;
+    public int totalEventElements = 0;
+    public final int pageSize = 3;
+    private int accountId = -1;
+
+    public void initialize(ClientUtils clientUtils,int accountId) {
+        this.clientUtils = clientUtils;
+        this.accountId = accountId;
+    }
+
+    public LiveData<String> getError() {
+        return error;
+    }
+
+    public LiveData<PagedResponse<GetEventDTO>> getFavouriteEvents() {
+        return favouriteEvents;
+    }
+
+    public void fetchEventPage(int page) {
+        clientUtils.getAccountService().getFavouriteEvents(accountId,page,pageSize)
+                .enqueue(new Callback<PagedResponse<GetEventDTO>>() {
+            @Override
+            public void onResponse(Call<PagedResponse<GetEventDTO>> call, Response<PagedResponse<GetEventDTO>> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    PagedResponse<GetEventDTO> pagedResponse = response.body();
+                    favouriteEvents.postValue(pagedResponse);
+                    currentEventPage = page;
+                    totalEventPages = pagedResponse.getTotalPages();
+                    totalEventElements = pagedResponse.getTotalElements();
+                } else {
+                    favouriteEvents.setValue(null);
+                    error.setValue("Failed to load page: " + page);
+                }
+            }
+
+            @Override
+            public void onFailure(Call<PagedResponse<GetEventDTO>> call, Throwable t) {
+                favouriteEvents.setValue(null);
+                error.setValue("Failed to load events: " + t.getMessage() + t.getStackTrace());
+            }
+        });
+    }
+
+    public void fetchNextEventPage() {
+        if (currentEventPage + 1 < totalEventPages) {
+            fetchEventPage(currentEventPage + 1);
+        } else {
+            error.setValue("No more pages to load.");
+        }
+    }
+
+    public void fetchPreviousEventPage() {
+        if (currentEventPage > 0) {
+            fetchEventPage(currentEventPage - 1);
+        } else {
+            error.setValue("Already on the first page.");
+        }
+    }
+}

--- a/EventPlanner/app/src/main/java/m3/eventplanner/fragments/user/FavouritesViewModel.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/fragments/user/FavouritesViewModel.java
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel;
 
 import m3.eventplanner.clients.ClientUtils;
 import m3.eventplanner.models.GetEventDTO;
+import m3.eventplanner.models.GetOfferingDTO;
 import m3.eventplanner.models.PagedResponse;
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -14,10 +15,14 @@ import retrofit2.Response;
 public class FavouritesViewModel extends ViewModel {
     private ClientUtils clientUtils;
     public final MutableLiveData<PagedResponse<GetEventDTO>> favouriteEvents = new MutableLiveData<>();
+    public final MutableLiveData<PagedResponse<GetOfferingDTO>> favouriteOfferings = new MutableLiveData<>();
     public final MutableLiveData<String> error = new MutableLiveData<>();
     public int currentEventPage = 0;
     public int totalEventPages = 0;
     public int totalEventElements = 0;
+    public int currentOfferingPage = 0;
+    public int totalOfferingPages = 0;
+    public int totalOfferingElements = 0;
     public final int pageSize = 3;
     private int accountId = -1;
 
@@ -32,6 +37,9 @@ public class FavouritesViewModel extends ViewModel {
 
     public LiveData<PagedResponse<GetEventDTO>> getFavouriteEvents() {
         return favouriteEvents;
+    }
+    public LiveData<PagedResponse<GetOfferingDTO>> getFavouriteOfferings() {
+        return favouriteOfferings;
     }
 
     public void fetchEventPage(int page) {
@@ -70,6 +78,47 @@ public class FavouritesViewModel extends ViewModel {
     public void fetchPreviousEventPage() {
         if (currentEventPage > 0) {
             fetchEventPage(currentEventPage - 1);
+        } else {
+            error.setValue("Already on the first page.");
+        }
+    }
+
+    public void fetchOfferingPage(int page) {
+        clientUtils.getAccountService().getFavouriteOfferings(accountId,page,pageSize)
+                .enqueue(new Callback<PagedResponse<GetOfferingDTO>>() {
+                    @Override
+                    public void onResponse(Call<PagedResponse<GetOfferingDTO>> call, Response<PagedResponse<GetOfferingDTO>> response) {
+                        if (response.isSuccessful() && response.body() != null) {
+                            PagedResponse<GetOfferingDTO> pagedResponse = response.body();
+                            favouriteOfferings.postValue(pagedResponse);
+                            currentOfferingPage = page;
+                            totalOfferingPages = pagedResponse.getTotalPages();
+                            totalOfferingElements = pagedResponse.getTotalElements();
+                        } else {
+                            favouriteOfferings.setValue(null);
+                            error.setValue("Failed to load page: " + page);
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Call<PagedResponse<GetOfferingDTO>> call, Throwable t) {
+                        favouriteEvents.setValue(null);
+                        error.setValue("Failed to load offerings: " + t.getMessage() + t.getStackTrace());
+                    }
+                });
+    }
+
+    public void fetchNextOfferingPage() {
+        if (currentOfferingPage + 1 < totalOfferingPages) {
+            fetchOfferingPage(currentOfferingPage + 1);
+        } else {
+            error.setValue("No more pages to load.");
+        }
+    }
+
+    public void fetchPreviousOfferingPage() {
+        if (currentOfferingPage > 0) {
+            fetchOfferingPage(currentOfferingPage - 1);
         } else {
             error.setValue("Already on the first page.");
         }

--- a/EventPlanner/app/src/main/res/layout/fragment_favourites.xml
+++ b/EventPlanner/app/src/main/res/layout/fragment_favourites.xml
@@ -42,7 +42,8 @@
             android:id="@+id/eventPaginationBar"
             layout="@layout/pagination_bar"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:visibility="gone"/>
 
         <TextView
             android:id="@+id/favourite_offerings_text"
@@ -77,7 +78,8 @@
             android:id="@+id/offeringPaginationBar"
             layout="@layout/pagination_bar"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:visibility="gone"/>
     </LinearLayout>
 
 

--- a/EventPlanner/app/src/main/res/layout/fragment_favourites.xml
+++ b/EventPlanner/app/src/main/res/layout/fragment_favourites.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".fragments.user.FavouritesFragment">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+        <TextView
+            android:id="@+id/favourite_events_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:padding="8dp"
+            android:text="@string/your_favourite_events"
+            android:textStyle="bold"
+            android:textSize="20sp"
+            android:textColor="@color/chocolate_brown"/>
+
+        <TextView
+            android:id="@+id/noEventsFoundTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:padding="16dp"
+            android:text="@string/no_events"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:visibility="gone"/>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/eventRecyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="8dp" />
+
+
+        <include
+            android:id="@+id/eventPaginationBar"
+            layout="@layout/pagination_bar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <TextView
+            android:id="@+id/favourite_offerings_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:padding="8dp"
+            android:text="@string/your_favourite_offerings"
+            android:textStyle="bold"
+            android:textSize="20sp"
+            android:textColor="@color/chocolate_brown"/>
+
+        <TextView
+            android:id="@+id/noOfferingsFoundTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:padding="16dp"
+            android:text="@string/no_offerings"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:visibility="gone"/>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/offeringRecyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="8dp" />
+
+
+        <include
+            android:id="@+id/offeringPaginationBar"
+            layout="@layout/pagination_bar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+
+
+</FrameLayout>

--- a/EventPlanner/app/src/main/res/menu/admin_nav_menu.xml
+++ b/EventPlanner/app/src/main/res/menu/admin_nav_menu.xml
@@ -34,6 +34,11 @@
                 android:title="@string/account_details"
                 android:checkable="true"
                 android:icon="@drawable/ic_profile"/>
+            <item
+                android:id="@+id/favouritesFragment"
+                android:title="@string/favourites"
+                android:checkable="true"
+                android:icon="@drawable/heart_filled"/>
         </menu>
     </item>
 </menu>

--- a/EventPlanner/app/src/main/res/menu/authenticated_user_nav_menu.xml
+++ b/EventPlanner/app/src/main/res/menu/authenticated_user_nav_menu.xml
@@ -29,6 +29,11 @@
                 android:title="@string/account_details"
                 android:checkable="true"
                 android:icon="@drawable/ic_profile"/>
+            <item
+                android:id="@+id/favouritesFragment"
+                android:title="@string/favourites"
+                android:checkable="true"
+                android:icon="@drawable/heart_filled"/>
         </menu>
     </item>
 </menu>

--- a/EventPlanner/app/src/main/res/menu/organizer_nav_menu.xml
+++ b/EventPlanner/app/src/main/res/menu/organizer_nav_menu.xml
@@ -29,6 +29,11 @@
                 android:title="@string/account_details"
                 android:checkable="true"
                 android:icon="@drawable/ic_profile"/>
+            <item
+                android:id="@+id/favouritesFragment"
+                android:title="@string/favourites"
+                android:checkable="true"
+                android:icon="@drawable/heart_filled"/>
         </menu>
     </item>
 </menu>

--- a/EventPlanner/app/src/main/res/menu/provider_nav_menu.xml
+++ b/EventPlanner/app/src/main/res/menu/provider_nav_menu.xml
@@ -34,6 +34,11 @@
                 android:title="@string/account_details"
                 android:checkable="true"
                 android:icon="@drawable/ic_profile"/>
+            <item
+                android:id="@+id/favouritesFragment"
+                android:title="@string/favourites"
+                android:checkable="true"
+                android:icon="@drawable/heart_filled"/>
         </menu>
     </item>
 </menu>

--- a/EventPlanner/app/src/main/res/navigation/base_navigation.xml
+++ b/EventPlanner/app/src/main/res/navigation/base_navigation.xml
@@ -115,4 +115,9 @@
         android:id="@+id/editEventFragment"
         android:name="m3.eventplanner.fragments.event.EditEventFragment"
         android:label="@string/edit_event" />
+    <fragment
+        android:id="@+id/favouritesFragment"
+        android:name="m3.eventplanner.fragments.user.FavouritesFragment"
+        android:label="@string/favourites"
+        tools:layout="@layout/fragment_favourites" />
 </navigation>

--- a/EventPlanner/app/src/main/res/values/strings.xml
+++ b/EventPlanner/app/src/main/res/values/strings.xml
@@ -154,4 +154,7 @@
     <string name="change_password">Change password</string>
     <string name="deactivate_account">Deactivate account</string>
     <string name="edit_event">Edit event</string>
+    <string name="your_favourite_events">Your Favourite Events</string>
+    <string name="your_favourite_offerings">Your Favourite Offerings</string>
+    <string name="favourites">Favourites</string>
 </resources>


### PR DESCRIPTION
This pull request introduces significant changes to the `EventPlanner` application to implement the "Favourites" feature. Key updates include adding a new `FavouritesFragment` and `FavouritesViewModel`, modifying navigation menus, and updating the `AccountService` API interface to support paginated and detailed retrieval of favourite events and offerings.

### Feature Enhancements: Favourites

* **New `FavouritesFragment` Implementation**: Added a new fragment to display paginated lists of favourite events and offerings, with pagination controls and error handling. 
* **New `FavouritesViewModel` Implementation**: Added a ViewModel to manage the state and API calls for favourite events and offerings, including pagination support. 
* **Updated Navigation Menus**: Added a "Favourites" menu item to all user navigation menus

### API Updates: AccountService

* **Paginated Favourite Events**: Modified the `getFavouriteEvents` API to support pagination and added a new `getFavouriteEvent` API for detailed retrieval of a single favourite event. 
* **Favourite Offerings API**: Added a new API to retrieve paginated favourite offerings. 

### Code Adjustments: Event Details

* **Simplified Favourite Status Check**: Updated logic in `EventDetailsViewModel` to use the new `getFavouriteEvent` API for checking if an event is a favourite, improving efficiency and error handling. 