### PR TITLE
Add User Blocking Functionality in Chat Module

### DIFF
--- a/EventPlanner/app/src/main/java/m3/eventplanner/clients/AccountService.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/clients/AccountService.java
@@ -2,7 +2,7 @@ package m3.eventplanner.clients;
 
 import m3.eventplanner.models.AddFavouriteEventDTO;
 import m3.eventplanner.models.AddFavouriteOfferingDTO;
-import m3.eventplanner.models.Event;
+import m3.eventplanner.models.BlockStatusDTO;
 import m3.eventplanner.models.GetCalendarItemDTO;
 import m3.eventplanner.models.GetEventDTO;
 import m3.eventplanner.models.GetOfferingDTO;
@@ -13,6 +13,7 @@ import retrofit2.http.DELETE;
 import retrofit2.http.GET;
 import retrofit2.http.Headers;
 import retrofit2.http.POST;
+import retrofit2.http.PUT;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 
@@ -71,5 +72,27 @@ public interface AccountService {
     })
     @GET("accounts/{accountId}/calendar")
     Call<Collection<GetCalendarItemDTO>> getCalendar(@Path("accountId") int accountId);
+
+    @Headers({
+            "User-Agent: Mobile-Android",
+            "Content-Type: application/json"
+    })
+    @GET("accounts/{loggedInId}/blocked-accounts/{accountToBlockId}")
+    Call<BlockStatusDTO> isAccountBlocked(@Path("loggedInId") int loggedInId, @Path("accountToBlockId") int accountToBlockId);
+
+    @Headers({
+            "User-Agent: Mobile-Android",
+            "Content-Type: application/json"
+    })
+    @PUT("accounts/{loggedInId}/block/{accountToBlockId}")
+    Call<Void> blockAccount(@Path("loggedInId") int loggedInId, @Path("accountToBlockId") int accountToBlockId);
+
+    @Headers({
+            "User-Agent: Mobile-Android",
+            "Content-Type: application/json"
+    })
+    @DELETE("accounts/{loggedInId}/unblock/{accountToUnblockId}")
+    Call<Void> unblockAccount(@Path("loggedInId") int loggedInId, @Path("accountToUnblockId") int accountToUnblockId);
+
 }
 

--- a/EventPlanner/app/src/main/java/m3/eventplanner/clients/EventService.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/clients/EventService.java
@@ -58,7 +58,8 @@ public interface EventService {
             @Query("name") String name,
             @Query("sortBy") String sortBy,
             @Query("sortDirection") String sortDirection,
-            @Query("accountId") Integer accountId
+            @Query("accountId") Integer accountId,
+            @Query("initLoad") Boolean initLoad
     );
 
     @Headers({

--- a/EventPlanner/app/src/main/java/m3/eventplanner/clients/OfferingService.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/clients/OfferingService.java
@@ -56,6 +56,7 @@ public interface OfferingService {
             @Query("sortBy") String sortBy,
             @Query("sortDirection") String sortDirection,
             @Query("accountId") Integer accountId,
+            @Query("initLoad") Boolean initLoad,
             @Query("providerId") Integer providerId
             );
 

--- a/EventPlanner/app/src/main/java/m3/eventplanner/fragments/block/BlockDialogFragment.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/fragments/block/BlockDialogFragment.java
@@ -1,0 +1,105 @@
+package m3.eventplanner.fragments.block;
+
+import android.app.Dialog;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+import androidx.lifecycle.ViewModelProvider;
+
+import m3.eventplanner.R;
+import m3.eventplanner.clients.ClientUtils;
+
+public class BlockDialogFragment extends DialogFragment {
+    private TextView blockedText, blockTitle;
+    private Button cancelButton, blockButton;
+    private int blockerId, toBeBlockedId;
+    private boolean blocked;
+    private BlockDialogViewModel viewModel;
+    private ClientUtils clientUtils;
+
+    public static BlockDialogFragment newInstance(int blockerId, int toBeBlockedId, boolean blocked) {
+        BlockDialogFragment fragment = new BlockDialogFragment();
+        Bundle args = new Bundle();
+        args.putInt("blockerId", blockerId);
+        args.putInt("toBeBlockedId", toBeBlockedId);
+        args.putBoolean("blocked", blocked);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(
+            @NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_block_user, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        viewModel = new ViewModelProvider(this).get(BlockDialogViewModel.class);
+        clientUtils = new ClientUtils(requireContext());
+        viewModel.initialize(clientUtils);
+
+        blockTitle = view.findViewById(R.id.blockTitle);
+        blockedText = view.findViewById(R.id.blockText);
+        cancelButton = view.findViewById(R.id.cancelBtn);
+        blockButton = view.findViewById(R.id.blockBtn);
+
+        if (getArguments() != null) {
+            blockerId = getArguments().getInt("blockerId");
+            toBeBlockedId = getArguments().getInt("toBeBlockedId");
+            blocked = getArguments().getBoolean("blocked");
+        }
+
+        viewModel.getSuccessMessage().observe(getViewLifecycleOwner(), message -> {
+            Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show();
+            Bundle result = new Bundle();
+            result.putBoolean("changed", true);
+            getParentFragmentManager().setFragmentResult("block_result", result);
+
+            dismiss();
+        });
+
+        viewModel.getErrorMessage().observe(getViewLifecycleOwner(), message -> {
+            Toast.makeText(requireContext(), message, Toast.LENGTH_LONG).show();
+            dismiss();
+        });
+
+        cancelButton.setOnClickListener(v -> dismiss());
+
+        blockButton.setOnClickListener(v -> {
+            viewModel.sendRequest(blocked, blockerId, toBeBlockedId);
+        });
+
+        checkBlockStatus();
+    }
+
+    private void checkBlockStatus(){
+        if(blocked){
+            blockTitle.setText(R.string.unblock_user);
+            blockedText.setText(R.string.are_you_sure_you_want_to_unblock_this_user);
+            blockButton.setText(R.string.unblock);
+        } else{
+            blockTitle.setText(R.string.block_user);
+            blockedText.setText(R.string.are_you_sure_you_want_to_block_this_user);
+            blockButton.setText(R.string.block);
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        Dialog dialog = getDialog();
+        if (dialog != null && dialog.getWindow() != null) {
+            dialog.getWindow().setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        }
+    }
+}

--- a/EventPlanner/app/src/main/java/m3/eventplanner/fragments/block/BlockDialogViewModel.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/fragments/block/BlockDialogViewModel.java
@@ -1,0 +1,86 @@
+package m3.eventplanner.fragments.block;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+import java.io.IOException;
+
+import m3.eventplanner.clients.ClientUtils;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class BlockDialogViewModel extends ViewModel {
+
+    private final MutableLiveData<String> successMessage = new MutableLiveData<>();
+    private final MutableLiveData<String> errorMessage = new MutableLiveData<>();
+
+    private ClientUtils clientUtils;
+
+    public void initialize(ClientUtils clientUtils) {
+        this.clientUtils = clientUtils;
+    }
+
+    public LiveData<String> getSuccessMessage() {
+        return successMessage;
+    }
+
+    public LiveData<String> getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void sendRequest(boolean blocked, Integer blockerId, Integer toBeBlockedId){
+        if(blocked){
+            unblock(blockerId, toBeBlockedId);
+        } else {
+            block(blockerId, toBeBlockedId);
+        }
+    }
+
+    private void block(Integer blockerId, Integer toBeBlockedId) {
+        clientUtils.getAccountService().blockAccount(blockerId, toBeBlockedId).enqueue(new Callback<Void>() {
+            @Override
+            public void onResponse(Call<Void> call, Response<Void> response) {
+                if (response.isSuccessful()) {
+                    successMessage.postValue("User blocked successfully.");
+                } else {
+                    try {
+                        String error = response.errorBody() != null ? response.errorBody().string() : "Unknown error";
+                        errorMessage.postValue(error);
+                    } catch (IOException e) {
+                        errorMessage.postValue("Error parsing server response");
+                    }
+                }
+            }
+
+            @Override
+            public void onFailure(Call<Void> call, Throwable t) {
+                errorMessage.postValue(t.getMessage() != null ? t.getMessage() : "Error blocking user");
+            }
+        });
+    }
+
+    private void unblock(Integer blockerId, Integer toBeBlockedId) {
+        clientUtils.getAccountService().unblockAccount(blockerId, toBeBlockedId).enqueue(new Callback<Void>() {
+            @Override
+            public void onResponse(Call<Void> call, Response<Void> response) {
+                if (response.isSuccessful()) {
+                    successMessage.postValue("User unblocked successfully.");
+                } else {
+                    try {
+                        String error = response.errorBody() != null ? response.errorBody().string() : "Unknown error";
+                        errorMessage.postValue(error);
+                    } catch (IOException e) {
+                        errorMessage.postValue("Error parsing server response");
+                    }
+                }
+            }
+
+            @Override
+            public void onFailure(Call<Void> call, Throwable t) {
+                errorMessage.postValue(t.getMessage() != null ? t.getMessage() : "Error unblocking user");
+            }
+        });
+    }
+}

--- a/EventPlanner/app/src/main/java/m3/eventplanner/fragments/home/HomeEventsViewModel.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/fragments/home/HomeEventsViewModel.java
@@ -79,12 +79,7 @@ public class HomeEventsViewModel extends ViewModel {
         });
     }
 
-    public void fetchPage(int page, Boolean initLoad, Integer accountId) {
-        if (Boolean.FALSE.equals(initLoad)) {
-            this.accountId=null;
-        }else{
-            this.accountId=accountId;
-        }
+    public void fetchPage(int page) {
         clientUtils.getEventService().getEvents(
                 page,
                 pageSize,
@@ -97,7 +92,8 @@ public class HomeEventsViewModel extends ViewModel {
                 searchQuery,
                 sortBy,
                 sortDirection,
-                this.accountId
+                accountId,
+                initLoad
         ).enqueue(new Callback<PagedResponse<GetEventDTO>>() {
             @Override
             public void onResponse(Call<PagedResponse<GetEventDTO>> call, Response<PagedResponse<GetEventDTO>> response) {
@@ -121,9 +117,15 @@ public class HomeEventsViewModel extends ViewModel {
         });
     }
 
+    public void loadEvents(int page, Boolean initialLoad, Integer accountId){
+        this.initLoad = initialLoad;
+        this.accountId = accountId;
+        fetchPage(page);
+    }
+
     public void fetchNextPage() {
         if (currentPage + 1 < totalPages) {
-            fetchPage(currentPage + 1, this.initLoad, this.accountId);
+            fetchPage(currentPage + 1);
         } else {
             error.setValue("No more pages to load.");
         }
@@ -131,7 +133,7 @@ public class HomeEventsViewModel extends ViewModel {
 
     public void fetchPreviousPage() {
         if (currentPage > 0) {
-            fetchPage(currentPage - 1, this.initLoad, this.accountId);
+            fetchPage(currentPage - 1);
         } else {
             error.setValue("Already on the first page.");
         }
@@ -145,23 +147,19 @@ public class HomeEventsViewModel extends ViewModel {
         this.filterStartDate = startDate;
         this.filterEndDate = endDate;
         this.initLoad = initialLoad;
-        if (!initialLoad){
-            this.accountId=null;
-        }else{
-            this.accountId=accountId;
-        }
-        fetchPage(page, this.initLoad, this.accountId);
+        this.accountId = accountId;
+        fetchPage(page);
     }
 
     public void loadSearchedEvents(int page, String query) {
         this.searchQuery = query;
-        fetchPage(page, this.initLoad, this.accountId);
+        fetchPage(page);
     }
 
     public void loadSortedEvents(int page, String sortBy, String sortDirection) {
         this.sortBy = sortBy;
         this.sortDirection = sortDirection;
-        fetchPage(page, this.initLoad, this.accountId);
+        fetchPage(page);
     }
 
     public void seeAll(){
@@ -180,7 +178,7 @@ public class HomeEventsViewModel extends ViewModel {
         this.sortBy = null;
         this.sortDirection = null;
 
-        fetchPage(0, this.initLoad, this.accountId);
+        fetchPage(0);
     }
 
     public void fetchEventTypes() {

--- a/EventPlanner/app/src/main/java/m3/eventplanner/fragments/home/HomeOfferingViewModel.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/fragments/home/HomeOfferingViewModel.java
@@ -87,9 +87,6 @@ public class HomeOfferingViewModel extends ViewModel {
     }
 
     public void fetchPage(int page) {
-        if(!initLoad || this.filterOfferingLocation != null){
-            accountId=null;
-        }
         clientUtils.getOfferingService().getOfferings(
                 page,
                 pageSize,
@@ -106,6 +103,7 @@ public class HomeOfferingViewModel extends ViewModel {
                 sortBy,
                 sortDirection,
                 accountId,
+                initLoad,
                 null
         ).enqueue(new Callback<PagedResponse<GetOfferingDTO>>() {
             @Override
@@ -156,11 +154,7 @@ public class HomeOfferingViewModel extends ViewModel {
         this.filterMinRating = minRating;
         this.filterIsAvailable = isAvailable;
         this.initLoad = initialLoad;
-        if (!initialLoad && this.filterOfferingLocation!=null){
-            this.accountId=null;
-        }else{
-            this.accountId=accountId;
-        }
+        this.accountId = accountId;
         fetchPage(page);
     }
 
@@ -179,11 +173,7 @@ public class HomeOfferingViewModel extends ViewModel {
     public void loadOfferings(int page, Boolean isService, Boolean initialLoad, Integer accountId){
         this.isService = isService;
         this.initLoad = initialLoad;
-        if (!initialLoad && this.filterOfferingLocation!=null){
-            this.accountId=null;
-        }else{
-            this.accountId=accountId;
-        }
+        this.accountId = accountId;
         fetchPage(page);
     }
 

--- a/EventPlanner/app/src/main/java/m3/eventplanner/fragments/home/HomeScreenFragment.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/fragments/home/HomeScreenFragment.java
@@ -284,7 +284,7 @@ public class HomeScreenFragment extends Fragment {
                 if (checkedId == R.id.tabTopEvents) {
                     eventsViewModel.loadTopEvents(loggedInID);
                 } else if (checkedId == R.id.tabAllEvents) {
-                    eventsViewModel.fetchPage(0, initialOfferingLoad, loggedInID);
+                    eventsViewModel.loadEvents(0, initialEventLoad, loggedInID);
                 } else if (checkedId == R.id.tabTopOfferings) {
                     offeringsViewModel.loadTopOfferings(loggedInID);
                 } else if (checkedId == R.id.tabAllOfferings) {

--- a/EventPlanner/app/src/main/java/m3/eventplanner/fragments/offering/ManageOfferingsViewModel.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/fragments/offering/ManageOfferingsViewModel.java
@@ -108,6 +108,7 @@ public class ManageOfferingsViewModel extends ViewModel {
                 sortBy,
                 sortDirection,
                 accountId,
+                false,
                 userId
 
         ).enqueue(new Callback<PagedResponse<GetOfferingDTO>>() {

--- a/EventPlanner/app/src/main/java/m3/eventplanner/models/BlockStatusDTO.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/models/BlockStatusDTO.java
@@ -1,0 +1,8 @@
+package m3.eventplanner.models;
+
+public class BlockStatusDTO {
+    boolean blocked;
+    public BlockStatusDTO(boolean blocked) {this.blocked = blocked;}
+
+    public boolean getIsBlocked() { return blocked; }
+}

--- a/EventPlanner/app/src/main/java/m3/eventplanner/models/BlockStatusPair.java
+++ b/EventPlanner/app/src/main/java/m3/eventplanner/models/BlockStatusPair.java
@@ -1,0 +1,20 @@
+package m3.eventplanner.models;
+
+public class BlockStatusPair {
+    private final boolean isBlockingThem;
+    private final boolean isBlockedByThem;
+
+    public BlockStatusPair(boolean isBlockingThem, boolean isBlockedByThem) {
+        this.isBlockingThem = isBlockingThem;
+        this.isBlockedByThem = isBlockedByThem;
+    }
+
+    public boolean isBlockingThem() {
+        return isBlockingThem;
+    }
+
+    public boolean isBlockedByThem() {
+        return isBlockedByThem;
+    }
+}
+

--- a/EventPlanner/app/src/main/res/layout/fragment_block_user.xml
+++ b/EventPlanner/app/src/main/res/layout/fragment_block_user.xml
@@ -1,0 +1,48 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/blockTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/block_user"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:layout_gravity="center_horizontal"
+        android:paddingBottom="16dp"/>
+
+    <TextView
+        android:id="@+id/blockText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/are_you_sure_you_want_to_block_this_user"
+        android:padding="12dp"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:orientation="horizontal"
+        android:gravity="end">
+
+        <Button
+            android:id="@+id/cancelBtn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/cancel"
+            android:textColor="@color/chocolate_brown"
+            android:backgroundTint="@color/design_default_color_surface"
+            android:layout_marginEnd="12dp" />
+
+        <Button
+            android:id="@+id/blockBtn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/block"
+            android:backgroundTint="@color/brand_purple"
+            android:textColor="@color/white" />
+    </LinearLayout>
+</LinearLayout>

--- a/EventPlanner/app/src/main/res/layout/fragment_chat.xml
+++ b/EventPlanner/app/src/main/res/layout/fragment_chat.xml
@@ -59,11 +59,41 @@
 
 
     <!-- Chat messages - fiksna visina -->
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="500dp">
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
-        android:layout_height="500dp"
+        android:layout_height="match_parent"
         android:overScrollMode="never" />
+
+    <LinearLayout
+        android:id="@+id/blockedOverlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#B3FFFFFF"
+        android:gravity="center"
+        android:visibility="gone"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <TextView
+            android:id="@+id/blockedTxt"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/you_have_been_blocked"
+            android:textColor="@android:color/black"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            android:background="@android:color/white"
+            android:padding="16dp"
+            android:elevation="10dp"/>
+    </LinearLayout>
+
+    </FrameLayout>
+
 
     <!-- Input and send - fiksna visina -->
     <LinearLayout

--- a/EventPlanner/app/src/main/res/values/strings.xml
+++ b/EventPlanner/app/src/main/res/values/strings.xml
@@ -200,4 +200,10 @@
     <string name="reports">Reports</string>
     <string name="no_reports_to_confirm">No reports to confirm</string>
     <string name="report_management">Report Management</string>
+    <string name="block_user">Block User</string>
+    <string name="are_you_sure_you_want_to_block_this_user">Are you sure you want to block this user?</string>
+    <string name="are_you_sure_you_want_to_unblock_this_user">Are you sure you want to unblock this user?</string>
+    <string name="unblock">Unblock</string>
+    <string name="you_have_been_blocked">You have been blocked</string>
+    <string name="unblock_user">Unblock User</string>
 </resources>


### PR DESCRIPTION
This PR introduces full support for blocking and unblocking users within the chat system, both in backend service calls and frontend interaction. The feature allows users to block/unblock others, restricts message sending when blocked, and visually informs users of their block status.

###  Backend Integration

* Added new **block/unblock** and **block status** endpoints in `AccountService.java`.
* Created `BlockStatusDTO` and `BlockStatusPair` for representing block relationships.

* Updated `ChatFragment` and `ChatViewModel` to:

  * Display block status between users.
  * Disable input and sending when blocked.
  * Show UI overlay explaining the block reason.
  * Listen for block changes via fragment result API.

###  Block Dialog

* Introduced `BlockDialogFragment` and `BlockDialogViewModel` to handle:

  * User interaction for confirming block/unblock actions.
  * Sending appropriate requests and reacting to success/failure responses.

###  UI Enhancements

* Added `fragment_block_user.xml` and other necessary resources to support the block dialog interface.

###  Home Page Adjustments

* Refactored `HomeEventsViewModel` and `HomeOfferingViewModel` to align with the updated frontend and accountId handling logic.